### PR TITLE
fix media_list_query so that it doesn't list manga

### DIFF
--- a/fastanime/libs/anilist/queries_graphql.py
+++ b/fastanime/libs/anilist/queries_graphql.py
@@ -127,7 +127,7 @@ query ($userId: Int, $status: MediaListStatus) {
         currentPage
         total
     }
-    mediaList(userId: $userId, status: $status) {
+    mediaList(userId: $userId, status: $status, type: ANIME) {
       mediaId
       
       media {


### PR DESCRIPTION
When using the anilist backend, the Watching list was showing currently read manga. This change makes it so that only currently watched anime are queried.

Nice app btw!