### PR TITLE
Add new episode indicators for airing shows

### DIFF
--- a/fastanime/cli/interfaces/anilist_interfaces.py
+++ b/fastanime/cli/interfaces/anilist_interfaces.py
@@ -745,6 +745,11 @@ def select_anime(config: Config, anilist_config: QueryDict):
             anime["title"][config.preferred_language] or anime["title"]["romaji"]
         )
         title = sanitize_filename(f"{title} ({progress} of {episodes_total})")
+        # Check if the anime is currently airing and has new/unwatched episodes
+        if anime["status"] == "RELEASING" and anime["nextAiringEpisode"] and progress > 0:
+            last_aired_episode = anime["nextAiringEpisode"]["episode"] - 1
+            if last_aired_episode - progress > 0:
+                title += f" 🔹{last_aired_episode - progress} new episode(s)🔹"
         anime_data[title] = anime
 
     choices = [*anime_data.keys(), "Back"]


### PR DESCRIPTION
This is a small addition that adds a new episode indicator to currently airing anime that the user is watching. It is helpful for seeing at a glance if there are any new episodes out for weekly anime. Below is a picture showing how it looks.

![fastanime](https://github.com/user-attachments/assets/f740f7f6-3a04-4adb-a72f-b9a91dfd552d)

