### PR TITLE
fix for nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1731676054,
+        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,10 @@
 
         src = ./.;
 
+        preBuild = ''
+          sed -i 's/rich>=13.9.2/rich>=13.8.1/' pyproject.toml
+        '';
+
         # Add runtime dependencies
         propagatedBuildInputs = with pythonPackages; [
           click

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
   "click>=8.1.7",
   "inquirerpy>=0.3.4",
   "requests>=2.32.3",
-  "rich>=13.8.1",
+  "rich>=13.9.2",
   "thefuzz>=0.22.1",
   "yt-dlp>=2024.10.7",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
   "click>=8.1.7",
   "inquirerpy>=0.3.4",
   "requests>=2.32.3",
-  "rich>=13.9.2",
+  "rich>=13.8.1",
   "thefuzz>=0.22.1",
   "yt-dlp>=2024.10.7",
 ]


### PR DESCRIPTION
the latest version of rich in nixpkgs is 13.8.1 so it refuses to build. Setting the minimum version lower didn't seem to cause any problems and the program worked correctly, but if the later version is required for a specific reason then it makes sense not to merge this if it will cause issues installing with python.

If that is the case, it'll just have to wait until a later version of rich is pushed in nixpkgs.

The flake.lock is just locking nixpkgs version, I'll try to update it whenever I can/its important unless someone else is already doing that.

I think also some of the external dependencies should be added to the flake but I'd have to do more testing with that and probably should be discussed first anyways so I won't include that in this PR.