### PR TITLE
Removed toggle-wrap from fzf options

### DIFF
--- a/viu_media/assets/defaults/fzf-opts
+++ b/viu_media/assets/defaults/fzf-opts
@@ -13,7 +13,7 @@
 --cycle
 --info=hidden
 --height=100%
---bind=right:accept,ctrl-/:toggle-preview,ctrl-space:toggle-wrap+toggle-preview-wrap
+--bind=right:accept,ctrl-/:toggle-preview,ctrl-space:toggle-preview-wrap
 --no-margin
 +m
 -i


### PR DESCRIPTION
In the latest fzf release toggle-wrap is not a key-bind option